### PR TITLE
Multiple fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/lib/tmp
 
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "minitest", "~> 5.0"
+gem 'pg'

--- a/lib/data_keeper.rb
+++ b/lib/data_keeper.rb
@@ -17,6 +17,7 @@ module DataKeeper
 
   @dump_definition_builders = {}
   @storage = nil
+  @database_config = -> { Rails.configuration.database_configuration[Rails.env] }
 
   def self.define_dump(name, type = :partial, &block)
     @dump_definition_builders[name.to_sym] = DefinitionBuilder.new(type, block)
@@ -57,6 +58,14 @@ module DataKeeper
 
   def self.storage=(value)
     @storage = value
+  end
+
+  def self.database_config=(value)
+    @database_config = value
+  end
+
+  def self.database_config
+    @database_config
   end
 
   def self.clear_dumps!

--- a/lib/data_keeper/database_config.rb
+++ b/lib/data_keeper/database_config.rb
@@ -1,7 +1,7 @@
 module DataKeeper
   module DatabaseConfig
     def database_connection_config
-      Rails.configuration.database_configuration[Rails.env]
+      @database_connection_config ||= DataKeeper.database_config.call
     end
 
     def psql_env

--- a/lib/data_keeper/definition.rb
+++ b/lib/data_keeper/definition.rb
@@ -33,6 +33,7 @@ module DataKeeper
       @tables = []
       @raw_sqls = {}
       @definition_block = definition_block
+      @on_after_load_block = nil
     end
 
     def evaluate!

--- a/test/data_keeper_test.rb
+++ b/test/data_keeper_test.rb
@@ -1,10 +1,6 @@
 require "test_helper"
 
 class DataKeeperTest < BaseTest
-  def test_that_it_has_a_version_number
-    assert ::DataKeeper::VERSION
-  end
-
   def test_asserts_on_dump_type
     assert_raises(DataKeeper::InvalidDumpType) do
       DataKeeper.define_dump(:name, "invalid")
@@ -26,5 +22,18 @@ class DataKeeperTest < BaseTest
     assert_raises(DataKeeper::DumpDoesNotExist) do
       DataKeeper.create_dump!("missing")
     end
+  end
+
+  def test_partial_dump_creation_by_tables
+    DataKeeper.define_dump(:name) do |d|
+      d.table "users"
+    end
+
+    User.create! name: "Pepe"
+
+    DataKeeper.create_dump! :name
+
+    assert_equal 1, @storage.files.size
+    assert_equal :name, @storage.files.first[:dump_name]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,17 +2,24 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "data_keeper"
 
 require "minitest/autorun"
+require 'active_record'
 
 class SimpleStorage
-  attr_reader :dir
+  attr_reader :dir, :files
 
   def initialize
     @dir = File.join File.expand_path("../lib", __dir__), "tmp"
+    @files = []
   end
 
   def save(file, filename, dump_name)
     FileUtils.mkdir_p File.join(@dir, "tmp")
-    File.cp file.path, File.join(@dir, dump_name)
+    FileUtils.cp file.path, File.join(@dir, dump_name.to_s)
+    @files.push(
+      path: File.join(@dir, dump_name.to_s),
+      filename: filename,
+      dump_name: dump_name
+    )
   end
 
   def retrieve(dump_name)
@@ -30,6 +37,38 @@ class BaseTest < Minitest::Test
   def teardown
     super
     DataKeeper.clear_dumps!
+    User.delete_all
+    Post.delete_all
     FileUtils.rmdir @storage.dir if File.file?(@storage.dir)
   end
+end
+
+DataKeeper.database_config = -> {
+  {
+    "username" => "elnner",
+    "password" => '',
+    "database" => "data_keeper_test"
+  }
+}
+
+connection_opts = { adapter: "postgresql", database: "data_keeper_test", username: "elnner" }
+ActiveRecord::Base.establish_connection(connection_opts)
+
+begin
+  ActiveRecord::Schema.define do
+    create_table :users do |t|
+      t.string :name
+    end
+
+    create_table :posts do |t|
+      t.string :title
+    end
+  end
+rescue ActiveRecord::StatementInvalid
+end
+
+class User < ActiveRecord::Base
+end
+
+class Post < ActiveRecord::Base
 end


### PR DESCRIPTION
- automatically refresh ar connection on after load blocks, to make sure AR knows the latest schema
- log the output of the commands if terraping has a logger set
- more consistent way to set `ar_internal_metadata`, even if the table is empty
- don't `ensure_schema_compatibility!` for partial dumps